### PR TITLE
feat(issues/9) : fix http error 429 Too Many Requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,11 +27,13 @@ program.parse(process.argv);
 const start = async () => {
   const sourceStore = {
     shopName: process.env.SOURCE_SHOPIFY_STORE,
+    autoLimit: true,
     accessToken: process.env.SOURCE_SHOPIFY_API_PASSWORD,
     apiVersion: '2023-10'
   }
   const destinationStore = {
     shopName: process.env.DESTINATION_SHOPIFY_STORE,
+    autoLimit: true,
     accessToken: process.env.DESTINATION_SHOPIFY_API_PASSWORD,
     apiVersion: '2023-10'
   }


### PR DESCRIPTION
# 429 Too Many Requests - [9](https://github.com/workwithpact/StoreDuplicator/issues/9)
---
The script stops because of API calls which exceed the authorized limit

Documentation : https://shopify.dev/docs/api/usage/rate-limits

Solution : add parameter `autoLimit` inside the Shopify object parameters
## Type of pull request
- [] New Feature
- [ ] QA Fixes
- [x] Hotfixes
- [ ] Release
- [x] Maintenance


## Beauty Shots 💃
Place relevant images here

## Areas of Risks
Please describe risks associated with this PR. Delete if not needed.

## Testing Procedure
Outline steps needed to test this feature. Delete if not needed or overkill.
